### PR TITLE
Allow RGB val to be passed as a single argument

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -7,7 +7,9 @@ const cli = meow(`
 	Examples
 	  $ rgb-hex 255 154 253
 	  ff9afd
-	  $ rgb-hex 'rgb(40, 42, 54)'
+		$ rgb-hex 234129131
+		ea8183
+		$ rgb-hex 'rgb(40, 42, 54)'
 	  282a36
 `);
 

--- a/cli.js
+++ b/cli.js
@@ -11,4 +11,4 @@ const cli = meow(`
 	  282a36
 `);
 
-console.log(rgbHex(cli.input.join(' ')));
+console.log(rgbHex(cli.input.length === 1 ? cli.input[0].toString().match(/.{1,3}/g).join() : cli.input.join(' ')));

--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,8 @@ $ rgb-hex --help
   Examples
     $ rgb-hex 255 154 253
     ff9afd
+    $ rgb-hex 234129131
+    ea8183
     $ rgb-hex 'rgb(40, 42, 54)'
     282a36
 ```


### PR DESCRIPTION
Made it so that the RGB val to can be passed as a single argument. Trying to get better at contributing to other repositories and thought this would be a good starting point 😄.